### PR TITLE
Add default acceptlist for Array.observe

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@
 	    	if(!(object instanceof Array) && !Array.isArray(object)) {
 	    		throw new TypeError("First argument to Array.observer is not an Array");
 	    	}
+            	acceptlist = acceptlist || ["add", "update", "delete", "splice"];
 	    	var arrayproxy = new Proxy(object,{get: function(target,property) {
 	    		if(property==="unobserve") {
 		    		return function(callback) {


### PR DESCRIPTION
Otherwise, failing to pass an `acceptlist` causes `Array.observe` to throw an error on splice operations. The default list here is the same one on the [MDN docs for Array.observe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/observe).