### PR TITLE
Fixed a typo: `object.unobserve`

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@
 	    	return proxy;
 	    };
 	    Array.unobserve = function(object,callback) {
-		  return object.unobserve(callback);
+		  return Object.unobserve(callback);
 	    }
 	}
 	Object.deepObserve = function(object,callback,parts) {


### PR DESCRIPTION
Ahem.. This typo has crept into the npm release.